### PR TITLE
ENH: Bump version to 0.2.2

### DIFF
--- a/elastix_napari/__init__.py
+++ b/elastix_napari/__init__.py
@@ -1,7 +1,7 @@
 __author__ = "Viktor van der Valk"
 __email__ = "v.o.van_der_valk@lumc.nl"
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 
 def get_module_version():


### PR DESCRIPTION
This new version has mainly just updated Python to 3.10 - 3.13: Pull request https://github.com/SuperElastix/elastix-napari/pull/44 commit 619b69d3712653f6234ac8531200fa4c5b160c6c